### PR TITLE
修复jsoneditor不支持关联关系的展示的BUG

### DIFF
--- a/resources/views/editor.blade.php
+++ b/resources/views/editor.blade.php
@@ -7,7 +7,7 @@
 
         @include('admin::form.error')
 
-        <div id="{{$name}}" style="width: 100%; height: 100%;"></div>
+        <div id="{{$id}}" style="width: 100%; height: 100%;"></div>
 
         <input type="hidden" name="{{$name}}" value="{{ old($column, $value) }}" />
         @include('admin::form.help-block')


### PR DESCRIPTION
例如：$form->json('article.content'); 问题定位为 $id 被 $name 代替，但单层元素展示没有问题