### PR TITLE
Create individual instance of editor for column

### DIFF
--- a/src/Editor.php
+++ b/src/Editor.php
@@ -38,15 +38,15 @@ class Editor extends Field
 // create the editor
 var container = document.getElementById("{$this->id}");
 var options = {$options};
-var editor = new JSONEditor(container, options);
+window['editor_{$this->id}'] = new JSONEditor(container, options);
 
 // set json
 var json = {$json};
-editor.set(json);
+window['editor_{$this->id}'].set(json);
 
 // get json
 $('button[type="submit"]').click(function() {
-var json = editor.get()
+var json = window['editor_{$this->id}'].get()
 $('input[id={$this->id}_input]').val(JSON.stringify(json))
 })
 EOT;


### PR DESCRIPTION
Currently if there are more than one editor in a page then the content from the last editor is overrides content of all other editor on submit.
This happens because editor is overridden.

```
$form->json('first_json_mapping_field', 'First');
$form->json('second_json_mapping_field','Second');
```
--->Submit the form and both the fields will have save data saved