### PR TITLE
修复初始化显示时html尾标签丢失问题

### DIFF
--- a/src/Editor.php
+++ b/src/Editor.php
@@ -26,7 +26,10 @@ class Editor extends Field
 
         if (!is_string($json)) {
             $json = json_encode($json);
+        } else {
+            $json = json_encode(json_decode($json,true));   //兼容json里有类似</p>格式，首次初始化显示会丢失的问题
         }
+        $this->value = $json;
 
         $options = json_encode(config('admin.extensions.json-editor.config'));
 


### PR DESCRIPTION
【改动记录】
1. 解决Model使用访问器 & 修改器，取出字段格式为数组时，页面报错的问题。
2. 兼容json里有类似<\/p> <\/b>等标签格式，首次初始化页面显示会丢失(手动再刷新一次页面后又正常)的问题。